### PR TITLE
chore: upgrade to Java 23

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,11 +14,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '23'
 
       - name: Run SonarCloud scan
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
@@ -34,11 +34,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '23'
 
       - name: Publish snapshot on GitHub Packages
         run: mvn -B clean deploy -DskipTests

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,11 +14,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '23'
 
       - name: Run SonarCloud scan
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,11 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
 
-      - name: Set up JDK 17
+      - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '23'
           server-id: github
 
       - name: Configure Git user

--- a/campsite-booking-service/pom.xml
+++ b/campsite-booking-service/pom.xml
@@ -71,6 +71,10 @@
             <artifactId>derby</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derbytools</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
@@ -122,6 +126,23 @@
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
                     <parameters>true</parameters>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct-processor.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>${lombok-mapstruct-binding.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <snakeyaml.version>2.2</snakeyaml.version>
         <mysql-connector-j.version>8.0.33</mysql-connector-j.version>
         <derby.version>10.17.1.0</derby.version>
+        <derby.tools.version>10.16.1.1</derby.tools.version>
         <lombok.version>1.18.36</lombok.version>
         <mapstruct-processor.version>1.5.3.Final</mapstruct-processor.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
@@ -135,6 +136,12 @@
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derby</artifactId>
                 <version>${derby.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbytools</artifactId>
+                <version>${derby.tools.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,20 +31,22 @@
     </modules>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>23</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Spring Boot -->
-        <spring-boot.version>3.1.5</spring-boot.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
         <!-- Auxiliary -->
         <spring-retry.version>2.0.3</spring-retry.version>
         <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <mysql-connector-j.version>8.0.33</mysql-connector-j.version>
         <derby.version>10.17.1.0</derby.version>
-        <lombok.version>1.18.30</lombok.version>
+        <lombok.version>1.18.36</lombok.version>
+        <mapstruct-processor.version>1.5.3.Final</mapstruct-processor.version>
+        <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <guava.version>32.0.0-jre</guava.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
         <flyway.core.version>9.22.3</flyway.core.version>
@@ -60,7 +62,7 @@
         <maven-surefire-plugin.version>3.2.1</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.2.1</maven-failsafe-plugin.version>
         <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-        <maven-jacoco-plugin.version>0.8.10</maven-jacoco-plugin.version>
+        <maven-jacoco-plugin.version>0.8.11</maven-jacoco-plugin.version>
         <openapi-generator-maven-plugin.version>6.5.0</openapi-generator-maven-plugin.version>
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <!-- Sonar Cloud -->


### PR DESCRIPTION
- Upgrade Spring Boot from 3.1.5 to 3.3.4
- Upgrade Lombok from 1.18.30 to 1.18.36
- Upgrade JaCoCo plugin from 0.8.10 to 0.8.11
- Add derbytools dependency
- Configure annotation processors for Lombok and MapStruct integration